### PR TITLE
Possibly a better match for syncprintf.c

### DIFF
--- a/src/libc/syncprintf.c
+++ b/src/libc/syncprintf.c
@@ -12,6 +12,8 @@ void osSyncPrintf(const char *fmt, ...) {
 }
 
 void rmonPrintf(const char *fmt, ...) {
-    int ans;
-    va_list ap;
+    va_list args;
+    va_start(args, fmt);
+    _Printf(osSyncPrintf, NULL, fmt, args);
+    va_end(args);
 }


### PR DESCRIPTION
Possibly a better match.

I also have:
```

char *osSyncPrintf(char *arg0, const char *arg1, size_t size)
{
    // This function left blank. Ifdeffed out in rom release
    return (1);
}
```
Dunno if that's better or not from what's currently there. I believe the hypothesis is that this func was used for formatting the output.