### PR TITLE
Fix `os_system.h`

### DIFF
--- a/include/PR/os_system.h
+++ b/include/PR/os_system.h
@@ -28,61 +28,86 @@
  *---------------------------------------------------------------------*/
 
 #ifndef _OS_SYSTEM_H_
-#define _OS_SYSTEM_H_
+#define	_OS_SYSTEM_H_
 
 #ifdef _LANGUAGE_C_PLUS_PLUS
 extern "C" {
 #endif
 
-#include "ultratypes.h"
-#include "os_exception.h"
+#include <PR/ultratypes.h>
+
+#if defined(_LANGUAGE_C) || defined(_LANGUAGE_C_PLUS_PLUS)
+
+/**************************************************************************
+ *
+ * Type definitions
+ *
+ */
+
+
+#endif /* defined(_LANGUAGE_C) || defined(_LANGUAGE_C_PLUS_PLUS) */
+
+/**************************************************************************
+ *
+ * Global definitions
+ *
+ */
 
 /*
  * Values for osTvType 
  */
-#define OS_TV_PAL   0
-#define OS_TV_NTSC  1
-#define OS_TV_MPAL  2
+#define	OS_TV_PAL		0
+#define	OS_TV_NTSC		1
+#define	OS_TV_MPAL		2
 
 /*
  * Size of buffer the retains contents after NMI
  */
-#define OS_APP_NMI_BUFSIZE  64
+#define OS_APP_NMI_BUFSIZE	64
+
 
 #if defined(_LANGUAGE_C) || defined(_LANGUAGE_C_PLUS_PLUS)
 
-extern s32   osRomType;     /* Bulk or cartridge ROM. 0=cartridge 1=bulk */
-extern void *osRomBase;     /* Rom base address of the game image */
-extern s32   osTvType;      /* 0 = PAL, 1 = NTSC, 2 = MPAL */
-extern s32   osResetType;   /* 0 = cold reset, 1 = NMI */
-extern s32   osCicId;
-extern s32   osVersion;
-extern u32   osMemSize;     /* Memory Size */
-extern s32   osAppNMIBuffer[OS_APP_NMI_BUFSIZE/sizeof(s32)];
-
-/*
- * CPU counter increments at 3/4 of bus clock rate:
+/**************************************************************************
  *
- * Bus Clock	Proc Clock	Counter (1/2 Proc Clock)
- * ---------	----------	------------------------
- * 62.5 Mhz	93.75 Mhz	46.875 Mhz
+ * Macro definitions
+ *
  */
-extern u64 osClockRate;
 
-extern OSIntMask __OSGlobalIntMask; /* global interrupt mask */
 
-#define osInitialize()          \
-    __osInitialize_common();    \
-    __osInitialize_autodetect()
+/**************************************************************************
+ *
+ * Extern variables
+ *
+ */
 
-void __osInitialize_common(void);
-void __osInitialize_autodetect(void);
+extern s32 	osRomType;	/* Bulk or cartridge ROM. 0=cartridge 1=bulk */
+extern void 	*osRomBase;	/* Rom base address of the game image */
+extern s32 	osTvType;	/* 0 = PAL, 1 = NTSC, 2 = MPAL */
+extern s32 	osResetType;	/* 0 = cold reset, 1 = NMI */
+extern s32 	osCicId;
+extern s32 	osVersion;
+extern u32	osMemSize;	/* Memory Size */
+extern s32	osAppNMIBuffer[];
 
-extern void     osExit(void);
-extern u32      osGetMemSize(void);
+extern u64	osClockRate;
+
+extern OSIntMask __OSGlobalIntMask;	/* global interrupt mask */
+
+
+/**************************************************************************
+ *
+ * Function prototypes
+ *
+ */
+
+extern void		osInitialize(void);
+extern void		osExit(void);
+extern u32 		osGetMemSize(void);
 
 /* pre-NMI */
-extern s32      osAfterPreNMI(void);
+extern s32		osAfterPreNMI(void);
+
 
 #endif  /* defined(_LANGUAGE_C) || defined(_LANGUAGE_C_PLUS_PLUS) */
 


### PR DESCRIPTION
Basically grabs the correct `os_system.h` header from the 2.0L version in the libultra collection.
I'm doing this PR only because I got tired of the redefined macro warning