### PR TITLE
Download egcs compiler binaries from repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,8 @@ build/
 expected/
 notes/
 tools/gcc
-tools/gcc-ique
+tools/egcs
+tools/egcs_original
 *.elf
 *.o
 *.a

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,13 @@ CPP := cpp -P
 AR := ar
 
 ifeq ($(findstring _iQue,$(TARGET)),_iQue)
-export COMPILER_PATH := $(WORKING_DIR)/tools/gcc-ique
-CC := mips-linux-gcc
-AR_OLD := mips-linux-ar
+export COMPILER_PATH := $(WORKING_DIR)/tools/egcs
 else
 export COMPILER_PATH := $(WORKING_DIR)/tools/gcc
-CC := $(WORKING_DIR)/tools/gcc/gcc
-AR_OLD := tools/gcc/ar
 endif
+CC := $(COMPILER_PATH)/gcc
+AR_OLD := $(COMPILER_PATH)/ar
+OBJCOPY := $(COMPILER_PATH)/objcopy
 
 REG_SIZES := -mgp32 -mfp32
 ifeq ($(findstring _iQue,$(TARGET)),_iQue)
@@ -73,8 +72,8 @@ MARKER_FILES := $(O_FILES:.o=.marker)
 ifneq ($(NON_MATCHING),1)
 
 ifeq ($(findstring _iQue,$(TARGET)),_iQue)
-COMPARE_OBJ = mips-linux-objcopy -p -S $(BASE_DIR)/$(@F:.marker=.o) $(BASE_DIR)/$(@F:.marker=.cmp.o) && \
-              mips-linux-objcopy -p -S $(WORKING_DIR)/$(@:.marker=.o) $(WORKING_DIR)/$(@:.marker=.cmp.o) && \
+COMPARE_OBJ = $(OBJCOPY) -p -S $(BASE_DIR)/$(@F:.marker=.o) $(BASE_DIR)/$(@F:.marker=.cmp.o) && \
+              $(OBJCOPY) -p -S $(WORKING_DIR)/$(@:.marker=.o) $(WORKING_DIR)/$(@:.marker=.cmp.o) && \
               dd if=$(BASE_DIR)/$(@F:.marker=.o) bs=1 count=4 skip=36 seek=36 conv=notrunc of=$(WORKING_DIR)/$(@:.marker=.cmp.o) 2>/dev/null && \
               cmp $(BASE_DIR)/$(@F:.marker=.cmp.o) $(WORKING_DIR)/$(@:.marker=.cmp.o) && echo "$(@:.marker=.o): OK"
 COMPARE_AR = echo "$@: Cannot compare archive currently"

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,10 +1,21 @@
 
 .PHONY: all clean distclean
+
 GCC_DIR   := gcc
 AR        := $(GCC_DIR)/ar
 GCC-2.7.2 := $(GCC_DIR)/gcc
 
-all: $(AR) $(GCC-2.7.2)
+EGCS_DIR := egcs
+EGCS-AS := $(EGCS_DIR)/as
+EGCS-1.1.2 := $(EGCS_DIR)/gcc
+
+all: $(AR) $(GCC-2.7.2) $(EGCS-AS) $(EGCS-1.1.2)
+
+clean:
+distclean: clean
+	$(RM) -rf $(GCC_DIR) $(EGCS_DIR)
+
+# GCC
 
 $(AR): | $(GCC_DIR)
 	wget https://github.com/decompals/mips-binutils-2.6/releases/download/main/binutils-2.6-linux.tar.gz
@@ -19,6 +30,17 @@ $(GCC-2.7.2): | $(GCC_DIR)
 $(GCC_DIR):
 	mkdir -p $@
 
-clean:
-distclean: clean
-	$(RM) -rf $(GCC_DIR)
+# EGCS
+
+$(EGCS-AS): | $(EGCS_DIR)
+	wget https://github.com/decompals/mips-binutils-egcs-2.9.5/releases/download/0.1/mips-binutils-egcs-2.9.5-linux.tar.gz
+	tar xf mips-binutils-egcs-2.9.5-linux.tar.gz -C $(EGCS_DIR)
+	$(RM) mips-binutils-egcs-2.9.5-linux.tar.gz
+
+$(EGCS-1.1.2): | $(EGCS_DIR)
+	wget https://github.com/decompals/mips-gcc-egcs-2.91.66/releases/download/0.1/mips-gcc-egcs-2.91.66-linux.tar.gz
+	tar xf mips-gcc-egcs-2.91.66-linux.tar.gz -C $(EGCS_DIR)
+	$(RM) mips-gcc-egcs-2.91.66-linux.tar.gz
+
+$(EGCS_DIR):
+	mkdir -p $@


### PR DESCRIPTION
No need to install them system-wide anymore
