### PR TITLE
Github Actions CI builds

### DIFF
--- a/.github/workflows/ci_egcs.txt
+++ b/.github/workflows/ci_egcs.txt
@@ -1,6 +1,7 @@
-# CI file for GCC/KMC builds
+# CI file for EGCS builds
+# TODO: rename to `ci_egcs.yml` when the repo has EGCS / iQue support
 
-name: Build GCC libgultra
+name: Build EGCS libultra
 
 # Build on every branch push, tag push, and pull request change:
 on: [push, pull_request_target]
@@ -13,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [L] # [H, I, I_patch, J, K, L]
+        version: [ique_v1.5]
         suffix: [_rom] # [, _d, _rom]
 
     steps:
@@ -35,7 +36,7 @@ jobs:
       run: cp deps_repo/libultra/${{ matrix.version }}/* .
 
     - name: Setup
-      run: make setup -j $(nproc) TARGET=libgultra${{ matrix.suffix }} VERSION=${{ matrix.version }}
+      run: make setup -j $(nproc) TARGET=libultra${{ matrix.suffix }} VERSION=${{ matrix.version }}
 
-    - name: Build libgultra${{ matrix.suffix }} ${{ matrix.version }}
-      run: make -j $(nproc) TARGET=libgultra${{ matrix.suffix }} VERSION=${{ matrix.version }}
+    - name: Build libultra${{ matrix.suffix }} ${{ matrix.version }}
+      run: make -j $(nproc) TARGET=libultra${{ matrix.suffix }} VERSION=${{ matrix.version }}

--- a/.github/workflows/ci_gcc.yml
+++ b/.github/workflows/ci_gcc.yml
@@ -1,0 +1,39 @@
+name: Build libgultra
+
+# Build on every branch push, tag push, and pull request change:
+on: [push, pull_request_target]
+
+jobs:
+  build_repo:
+    name: Build repo
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [L] # [H, I, I_patch, J, K, L]
+        suffix: [_rom] # [, _d, _rom]
+
+    steps:
+    - name: Checkout reposistory
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Install package requirements
+      run: sudo apt-get install -y build-essential python3
+
+    - name: Get extra dependencies
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ secrets.SECRETREPO }}
+        token: ${{ secrets.SECRETTOKEN }}
+        path: deps_repo
+    - name: Get the dependency
+      run: cp deps_repo/libultra/${{ matrix.version }}/* .
+
+    - name: Setup
+      run: make setup -j $(nproc) TARGET=libgultra${{ matrix.suffix }} VERSION=${{ matrix.version }}
+
+    - name: Build libgultra${{ matrix.suffix }} ${{ matrix.version }}
+      run: make -j $(nproc) TARGET=libgultra${{ matrix.suffix }} VERSION=${{ matrix.version }}

--- a/.github/workflows/ci_ido.txt
+++ b/.github/workflows/ci_ido.txt
@@ -1,6 +1,7 @@
-# CI file for GCC/KMC builds
+# CI file for IDO builds
+# TODO: rename to `ci_ido.yml` when the repo has IDO support
 
-name: Build GCC libgultra
+name: Build IDO libultra
 
 # Build on every branch push, tag push, and pull request change:
 on: [push, pull_request_target]
@@ -13,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [L] # [H, I, I_patch, J, K, L]
+        version: [L] # [E, F, G, H, I, I_patch, J, K, L]
         suffix: [_rom] # [, _d, _rom]
 
     steps:
@@ -35,7 +36,7 @@ jobs:
       run: cp deps_repo/libultra/${{ matrix.version }}/* .
 
     - name: Setup
-      run: make setup -j $(nproc) TARGET=libgultra${{ matrix.suffix }} VERSION=${{ matrix.version }}
+      run: make setup -j $(nproc) TARGET=libultra${{ matrix.suffix }} VERSION=${{ matrix.version }}
 
-    - name: Build libgultra${{ matrix.suffix }} ${{ matrix.version }}
-      run: make -j $(nproc) TARGET=libgultra${{ matrix.suffix }} VERSION=${{ matrix.version }}
+    - name: Build libultra${{ matrix.suffix }} ${{ matrix.version }}
+      run: make -j $(nproc) TARGET=libultra${{ matrix.suffix }} VERSION=${{ matrix.version }}


### PR DESCRIPTION
Add CI builds for checking gcc/kmc libultra files.
I also added some "template" files for IDO and EGCS for when the repo adds support for those compilers.

The PR will most likely fail the first time because the repository will be missing the corresponding secret tokens.