### PR TITLE
[iQue] Only strip debug sections when comparing objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NON_MATCHING ?= 0
 
-TARGET := libultra_rom_iQue
+TARGET := libgultra_rom
 BASE_DIR := base_$(TARGET)
 BASE_AR := $(TARGET).a
 BUILD_DIR := build

--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,12 @@ else
 MIPS_VERSION := -mips3
 endif
 
-CFLAGS := -w -nostdinc -c -G 0 -D_LANGUAGE_C
+CFLAGS := -Wa,-irix-symtab -w -nostdinc -c -G 0 -D_LANGUAGE_C
 ifeq ($(findstring _iQue,$(TARGET)),_iQue)
 CFLAGS += -fno-PIC  -mno-abicalls -mcpu=4300 -D__sgi
 endif
 
-ASFLAGS := -non_shared -fno-PIC -w -nostdinc -mcpu=4300 -c -G 0 -DMIPSEB -D_LANGUAGE_ASSEMBLY -D_MIPS_SIM=1 -D_ULTRA64 -x assembler-with-cpp
+ASFLAGS := -Wa,-irix-symtab -non_shared -fno-PIC -w -nostdinc -mcpu=4300 -c -G 0 -DMIPSEB -D_LANGUAGE_ASSEMBLY -D_MIPS_SIM=1 -D_ULTRA64 -x assembler-with-cpp
 
 GBIDEFINE := -DF3DEX_GBI_2
 CPPFLAGS = -D_MIPS_SZLONG=32 -D__USE_ISOC99 -I $(WORKING_DIR)/include -I $(WORKING_DIR)/include/gcc -I $(WORKING_DIR)/include/PR $(GBIDEFINE)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NON_MATCHING ?= 0
 
-TARGET := libgultra_rom
+TARGET := libultra_rom_iQue
 BASE_DIR := base_$(TARGET)
 BASE_AR := $(TARGET).a
 BUILD_DIR := build

--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,8 @@ MARKER_FILES := $(O_FILES:.o=.marker)
 ifneq ($(NON_MATCHING),1)
 
 ifeq ($(findstring _iQue,$(TARGET)),_iQue)
-COMPARE_OBJ = $(OBJCOPY) -p -S $(BASE_DIR)/$(@F:.marker=.o) $(BASE_DIR)/$(@F:.marker=.cmp.o) && \
-              $(OBJCOPY) -p -S $(WORKING_DIR)/$(@:.marker=.o) $(WORKING_DIR)/$(@:.marker=.cmp.o) && \
-              dd if=$(BASE_DIR)/$(@F:.marker=.o) bs=1 count=4 skip=36 seek=36 conv=notrunc of=$(WORKING_DIR)/$(@:.marker=.cmp.o) 2>/dev/null && \
+COMPARE_OBJ = $(OBJCOPY) -p --strip-debug $(BASE_DIR)/$(@F:.marker=.o) $(BASE_DIR)/$(@F:.marker=.cmp.o) && \
+              $(OBJCOPY) -p --strip-debug $(WORKING_DIR)/$(@:.marker=.o) $(WORKING_DIR)/$(@:.marker=.cmp.o) && \
               cmp $(BASE_DIR)/$(@F:.marker=.cmp.o) $(WORKING_DIR)/$(@:.marker=.cmp.o) && echo "$(@:.marker=.o): OK"
 COMPARE_AR = echo "$@: Cannot compare archive currently"
 else

--- a/include/PR/os_message.h
+++ b/include/PR/os_message.h
@@ -74,10 +74,15 @@ typedef struct OSMesgQueue_s {
  */
 
 /* Events */
-#ifdef _FINALROM
-#define OS_NUM_EVENTS           15
+#ifdef BBPLAYER
+ /* TODO debug version */
+ #define OS_NUM_EVENTS          34
 #else
-#define OS_NUM_EVENTS           23
+# ifdef _FINALROM
+#  define OS_NUM_EVENTS         15
+# else
+#  define OS_NUM_EVENTS         23
+# endif
 #endif
 
 #define OS_EVENT_SW1              0     /* CPU SW1 interrupt */

--- a/include/macros.h
+++ b/include/macros.h
@@ -1,7 +1,17 @@
 #ifndef __MACROS_H__
 #define __MACROS_H__
 
-#define ALIGNED(x) __attribute__((aligned(x)))
+#ifndef BBPLAYER
+# define ALIGNED(x) __attribute__((aligned(x)))
+# define BBALIGNED(x) ALIGNED(x)
+#else
+# define ALIGNED(x)
+# define BBALIGNED(x) __attribute__((aligned(x)))
+#endif
+
+#if defined(__GNUC__) && (__GNUC__ == 2) && (__GNUC_MINOR__ == 91)
+#define __EGCS__
+#endif
 
 #define ALIGN(x, n) (((x) + ((n) - 1)) & ~((n) -1))
 

--- a/include/sys/asm.h
+++ b/include/sys/asm.h
@@ -1,7 +1,7 @@
 /************************************************************************
  Copyright (C) 1998,1999 NINTENDO Co,Ltd,
  Copyright (C) 1998,1999 MONEGI CORPORATION,
-	All Rights Reserved
+    All Rights Reserved
 This program is a trade secret of NINTENDO Co,Ltd and MONEGI Corp. 
 and it is not to be reproduced, published, disclosed to others, copied,
 adapted, distributed, or displayed without the prior authorization of 
@@ -22,49 +22,84 @@ modified versions thereof.
 extern "C" {
 #endif
 
-#define _MIPS_ISA_MIPS1	1	/* R2/3K */
-#define _MIPS_ISA_MIPS2	2	/* R4K/6K */
-#define _MIPS_ISA_MIPS3	3	/* R4K */
-#define _MIPS_ISA_MIPS4	4	/* TFP */
+#define _MIPS_ISA_MIPS1 1   /* R2/3K */
+#define _MIPS_ISA_MIPS2 2   /* R4K/6K */
+#define _MIPS_ISA_MIPS3 3   /* R4K */
+#define _MIPS_ISA_MIPS4 4   /* TFP */
 
-#define _MIPS_SIM_ABI32		1	/* MIPS MSIG calling convention */
-#define _MIPS_SIM_NABI32	2	/* MIPS new 32-bit abi */
-		/* NABI32 is 64bit calling convention but 32bit type sizes) */
-#define _MIPS_SIM_ABI64		3	/* MIPS 64 calling convention */
+#define _MIPS_SIM_ABI32     1   /* MIPS MSIG calling convention */
+#define _MIPS_SIM_NABI32    2   /* MIPS new 32-bit abi */
+        /* NABI32 is 64bit calling convention but 32bit type sizes) */
+#define _MIPS_SIM_ABI64     3   /* MIPS 64 calling convention */
 
-#define	LEAF(x)						\
-	.globl	x;					\
-	.ent	x,0;					\
-x:;							\
-	.frame	sp,0,ra
 
-#define	XLEAF(x)					\
-	.global x;
+#define LEAF(x)             \
+    .globl  x              ;\
+    .align  2              ;\
+    .ent    x,0            ;\
+    x:                     ;\
+    .frame  sp,0,ra
+    //.type   x, @function   ;\
 
-#define	END(proc)					\
-	.end	proc
-
-#define	ABS(x, y)					\
-	.globl	x;					\
-	x	=	y
-	
-#define	EXPORT(x)					\
-	.globl	x;					\
-x:
+#if defined(BBPLAYER) || defined(__sgi)
+#define XLEAF(x)    \
+    .globl  x      ;\
+    x:
+#else
+#define XLEAF(x)    \
+    .globl  x
+#endif
 
 #ifdef BBPLAYER
-#define WEAK(x, y) \
-	.weak x; \
-	.equ x, y;
+#define END(proc)           \
+    .end    proc           ;\
+    .size   proc, . - proc
+#else
+#define END(proc)           \
+    .end    proc
+#endif
+
+#define ABS(x, y)   \
+    .globl  x      ;\
+    x   =   y
+
+#define EXPORT(x)   \
+    .globl  x      ;\
+    x:
+
+#ifdef BBPLAYER
+#define WEAK(x, y)  \
+    .weakext    x, y
 #else
 #define WEAK(x, y)
 #endif
 
-#define STAY1(stmnt) .set noreorder; stmnt; .set reorder;
-#define STAY2(stmnt, arg1) .set noreorder; stmnt, arg1; .set reorder;
-#define STAY3(stmnt, arg1, arg2) .set noreorder; stmnt, arg1, arg2; .set reorder;
-#define NOP .set noreorder; nop; .set reorder;
-#define CACHE(op, reg) .set noreorder; cache op, reg; .set reorder;
+
+
+#define STAY1(stmnt)    \
+    .set noreorder     ;\
+        stmnt          ;\
+    .set reorder
+
+#define STAY2(stmnt, arg1)  \
+    .set noreorder         ;\
+        stmnt, arg1        ;\
+    .set reorder
+
+#define STAY3(stmnt, arg1, arg2)    \
+    .set noreorder                 ;\
+        stmnt, arg1, arg2          ;\
+    .set reorder
+
+#define NOP         \
+    .set noreorder ;\
+        nop        ;\
+    .set reorder
+
+#define CACHE(op, reg)  \
+    .set noreorder     ;\
+        cache op, reg  ;\
+    .set reorder
 
 #ifdef __cplusplus
 }

--- a/include/sys/asm.h
+++ b/include/sys/asm.h
@@ -36,14 +36,15 @@ extern "C" {
 #define LEAF(x)             \
     .globl  x              ;\
     .align  2              ;\
+    .type   x, @function   ;\
     .ent    x,0            ;\
     x:                     ;\
     .frame  sp,0,ra
-    //.type   x, @function   ;\
 
 #if defined(BBPLAYER) || defined(__sgi)
 #define XLEAF(x)    \
     .globl  x      ;\
+    .aent   x,0    ;\
     x:
 #else
 #define XLEAF(x)    \
@@ -55,7 +56,7 @@ extern "C" {
     .end    proc           ;\
     .size   proc, . - proc
 #else
-#define END(proc)           \
+#define END(proc)   \
     .end    proc
 #endif
 
@@ -67,9 +68,9 @@ extern "C" {
     .globl  x      ;\
     x:
 
-#ifdef BBPLAYER
-#define WEAK(x, y)  \
-    .weakext    x, y
+#if defined(BBPLAYER) || defined(__sgi)
+#define WEAK(x, y)      \
+    .weakext    x,  y
 #else
 #define WEAK(x, y)
 #endif

--- a/include/sys/asm.h
+++ b/include/sys/asm.h
@@ -33,10 +33,17 @@ extern "C" {
 #define _MIPS_SIM_ABI64     3   /* MIPS 64 calling convention */
 
 
+// libgultra doesn't match with the .type directive but iQue sdk asm.h uses it
+#ifdef BBPLAYER
+#define ASM_TYPE_FUNC(x)    .type   x, @function
+#else
+#define ASM_TYPE_FUNC(x)
+#endif
+
 #define LEAF(x)             \
     .globl  x              ;\
     .align  2              ;\
-    .type   x, @function   ;\
+    ASM_TYPE_FUNC(x)       ;\
     .ent    x,0            ;\
     x:                     ;\
     .frame  sp,0,ra

--- a/include/sys/asm.h
+++ b/include/sys/asm.h
@@ -33,7 +33,7 @@ extern "C" {
 #define _MIPS_SIM_ABI64     3   /* MIPS 64 calling convention */
 
 
-// libgultra doesn't match with the .type directive but iQue sdk asm.h uses it
+/* libgultra doesn't match with the .type directive but iQue sdk asm.h uses it */
 #ifdef BBPLAYER
 #define ASM_TYPE_FUNC(x)    .type   x, @function
 #else

--- a/src/bb/card/cardwrite.c
+++ b/src/bb/card/cardwrite.c
@@ -9,7 +9,9 @@ s32 __osBbCardStatus(u32 dev, u8* status, u32 buf);
 
 extern u8 __osBbCardMultiplane;
 
+#ifdef _DEBUG
 u8 __osBbCardNoEcc;
+#endif
 
 static void fill_page(unsigned int dev, unsigned int addr, int which_buf, int wait) {
     IO_WRITE(PI_70_REG, addr << 9);

--- a/src/bb/sk/skapi.s
+++ b/src/bb/sk/skapi.s
@@ -21,6 +21,7 @@
     END(name)
 
 SK_FUNC(skGetId,                0)
+.type symbol, @function // ??? needed to match symbol table
 SK_FUNC(skLaunchSetup,          1)
 SK_FUNC(skLaunch,               2)
 SK_FUNC(skRecryptListValid,     3)

--- a/src/bb/usb/usbwrite.c
+++ b/src/bb/usb/usbwrite.c
@@ -22,7 +22,7 @@ s32 osBbUsbDevWrite(OSBbUsbHandle h, u8* buf, s32 len, u64 off) {
     um.um_rq = &rq;
 
     osCreateMesgQueue(&rq, &rmsg, 1);
-    osInvalDCache(buf, len);
+    osWritebackDCache(buf, len);
 
     wtotal = 0;
     while (len > 0) {

--- a/src/gt/dumpturbo.c
+++ b/src/gt/dumpturbo.c
@@ -232,7 +232,7 @@ gtDumpTurbo(OSTask *tp,u8 flags)
 	
 	if (flags & GT_DUMPTURBO_HANGAFTER) {
 		for (i=0; i<1000;i++) 
-			rmonPrintf("=======================================\n");
+			PRINTF("=======================================\n");
 		while(1);
 	}
 		

--- a/src/gu/cosf.c
+++ b/src/gu/cosf.c
@@ -30,8 +30,13 @@
  * ====================================================================
  */
 
+#include "macros.h"
+#ifdef __EGCS__
+float cosf(float) __attribute__ ((weak, alias ("__cosf")));
+#else
 #pragma weak fcos = __cosf
 #pragma weak cosf = __cosf
+#endif
 #define	fcos __cosf
 
 /* coefficients for polynomial approximation of cos on +/- pi/2 */

--- a/src/gu/sinf.c
+++ b/src/gu/sinf.c
@@ -30,9 +30,15 @@
  * ====================================================================
  */
 
+#include "macros.h"
+#ifdef __EGCS__
+float sinf(float) __attribute__ ((weak, alias ("__sinf")));
+#else
 #pragma weak fsin = __sinf
 #pragma weak sinf = __sinf
+#endif
 #define	fsin __sinf
+
 
 /* coefficients for polynomial approximation of sin on +/- pi/2 */
 

--- a/src/io/conteepread.c
+++ b/src/io/conteepread.c
@@ -12,8 +12,10 @@ extern u32 __osBbEepromAddress;
 extern u32 __osBbEepromSize;
 
 static void __osPackEepReadData(u8 address);
-OSPifRam __osEepPifRam ALIGNED(16);
+OSPifRam __osEepPifRam BBALIGNED(16);
+#ifndef BBPLAYER
 s32 __osEepromRead16K;
+#endif
 
 s32 osEepromRead(OSMesgQueue *mq, u8 address, u8 *buffer) {
 #ifdef BBPLAYER

--- a/src/io/controller.c
+++ b/src/io/controller.c
@@ -15,7 +15,7 @@ void __osSiCreateAccessQueue(void);
 
 s32 __osContinitialized = 0;
 
-OSPifRam __osContPifRam ALIGNED(16);
+OSPifRam __osContPifRam BBALIGNED(16);
 u8 __osContLastCmd;
 u8 __osMaxControllers;
 

--- a/src/io/gbpakinit.c
+++ b/src/io/gbpakinit.c
@@ -8,9 +8,11 @@
 #ident "$Revision: 1.1 $"
 #endif
 
+#ifndef BBPLAYER
 OSTimer __osGbpakTimer;
 OSMesg __osGbpakTimerMsg;
 OSMesgQueue __osGbpakTimerQ ALIGNED(8);
+#endif
 
 s32 osGbpakInit(OSMesgQueue* mq, OSPfs* pfs, int channel) {
 #ifdef BBPLAYER

--- a/src/io/pfsisplug.c
+++ b/src/io/pfsisplug.c
@@ -11,7 +11,7 @@ extern u32 __osBbIsBb;
 extern u32 __osBbHackFlags;
 extern u32 __osBbPakAddress[4];
 
-OSPifRam __osPfsPifRam ALIGNED(16);
+OSPifRam __osPfsPifRam BBALIGNED(16);
 
 s32 osPfsIsPlug(OSMesgQueue* mq, u8* pattern) {
     s32 ret = 0;

--- a/src/libc/bcmp.s
+++ b/src/libc/bcmp.s
@@ -3,8 +3,14 @@
 #include "sys/regdef.h"
 
 .text
-WEAK(_bcmp, bcmp)
-LEAF(bcmp)
+
+#if defined(BBPLAYER) || defined(__sgi)
+WEAK(bcmp, _bcmp)
+#else
+#define _bcmp bcmp
+#endif
+
+LEAF(_bcmp)
     xor v0, a0, a1
     blt a2, 16, bytecmp
 
@@ -88,5 +94,5 @@ cmpdone:
 cmpne:
     li v0, 1
     jr ra
-    
-END(bcmp)
+
+.end _bcmp

--- a/src/libc/bcopy.s
+++ b/src/libc/bcopy.s
@@ -4,13 +4,13 @@
 
 .text
 
-#ifdef BBPLAYER
+#if defined(BBPLAYER) || defined(__sgi)
 WEAK(bcopy, _bcopy)
-LEAF(_bcopy)
 #else
-WEAK(_bcopy, bcopy)
-LEAF(bcopy)
+#define _bcopy bcopy
 #endif
+
+LEAF(_bcopy)
 
     addu a3, a1, zero
     beqz a2, ret
@@ -220,11 +220,4 @@ backwards_4:
     addiu a2, a2, -4
     b backwards_4
 
-#ifdef BBPLAYER
-END(_bcopy)
-#else
-END(bcopy)
-#endif
-
-/*
-*/
+.end _bcopy

--- a/src/libc/bzero.s
+++ b/src/libc/bzero.s
@@ -3,10 +3,17 @@
 #include "sys/regdef.h"
 
 .text
-WEAK(_bzero, bzero)
-WEAK(_blkclr, blkclr)
-LEAF(bzero)
-XLEAF(blkclr)
+
+#if defined(BBPLAYER) || defined(__sgi)
+WEAK(bzero, _bzero)
+WEAK(blkclr, _blkclr)
+#else
+#define _bzero bzero
+#define _blkclr blkclr
+#endif
+
+LEAF(_bzero)
+XLEAF(_blkclr)
     negu v1, a0
     blt a1, 12, bytezero
 
@@ -55,4 +62,5 @@ bytezero:
     bne a0, a1, 1b
 zerodone:
     jr ra
-END(bzero)
+
+.end _bzero

--- a/src/os/getcompare.s
+++ b/src/os/getcompare.s
@@ -11,4 +11,7 @@ LEAF(__osGetCompare)
     jr ra
 END(__osGetCompare)
 
+#else
+// needed to match elf header flags
+.set noreorder
 #endif

--- a/src/os/getcount.s
+++ b/src/os/getcount.s
@@ -11,4 +11,7 @@ LEAF(osGetCount)
     jr ra
 END(osGetCount)
 
+#else
+// needed to match elf header flags
+.set noreorder
 #endif

--- a/src/os/getfpccsr.s
+++ b/src/os/getfpccsr.s
@@ -6,5 +6,4 @@
 LEAF(__osGetFpcCsr)
     STAY2(cfc1 v0, fcr31)
     jr ra
-END(__osGetFpcCsr)
-.globl __osGetSR
+END(__osGetSR)

--- a/src/os/getintmask.s
+++ b/src/os/getintmask.s
@@ -39,4 +39,5 @@ LEAF(osGetIntMask)
     sll t2, t1, 0x10
     or v0, v0, t2
     jr ra
+    nop
 END(osGetIntMask)

--- a/src/os/setcompare.s
+++ b/src/os/setcompare.s
@@ -11,4 +11,7 @@ LEAF(__osSetCompare)
     jr ra
 END(__osSetCompare)
 
+#else
+// needed to match elf header flags
+.set noreorder
 #endif

--- a/src/os/setcount.s
+++ b/src/os/setcount.s
@@ -11,4 +11,7 @@ LEAF(__osSetCount)
     jr ra
 END(__osSetCount)
 
+#else
+// needed to match elf header flags
+.set noreorder
 #endif

--- a/src/os/setfpccsr.s
+++ b/src/os/setfpccsr.s
@@ -7,5 +7,4 @@ LEAF(__osSetFpcCsr)
     STAY2(cfc1 v0, fcr31)
     STAY2(ctc1 a0, fcr31)
     jr ra
-END(__osSetFpcCsr)
-.globl __osSetSR
+END(__osSetSR)

--- a/src/reg/_setcompare.c
+++ b/src/reg/_setcompare.c
@@ -7,7 +7,7 @@ extern u32 __osBbRCountWraps;
 extern u32 __osBbLastVCount;
 extern u32 __osBbVCountWraps;
 
-void osGetCompare(u32 v) {
+void __osSetCompare(u32 v) {
     if (v != 0) {
         register u32 mask = __osDisableInt();
         u32 wraps = (v < __osBbLastVCount) ? __osBbVCountWraps + 1 : __osBbVCountWraps;

--- a/src/reg/_setcount.c
+++ b/src/reg/_setcount.c
@@ -1,6 +1,6 @@
 #include "PR/os_internal.h"
 
-void osSetCount(u32 v) {
+void __osSetCount(u32 v) {
     v = v * 192ull / 125ull;
     __asm__ ("mtc0 %0, $9" :: "r"(v));
 }

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -18,7 +18,7 @@ distclean: clean
 # GCC
 
 $(AR): | $(GCC_DIR)
-	wget https://github.com/decompals/mips-binutils-2.6/releases/download/main/binutils-2.6-linux.tar.gz
+	wget https://github.com/decompals/mips-binutils-2.6/releases/download/v0.2/binutils-2.6-linux.tar.gz
 	tar xf binutils-2.6-linux.tar.gz -C $(GCC_DIR)
 	$(RM) binutils-2.6-linux.tar.gz
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -33,12 +33,12 @@ $(GCC_DIR):
 # EGCS
 
 $(EGCS-AS): | $(EGCS_DIR)
-	wget https://github.com/decompals/mips-binutils-egcs-2.9.5/releases/download/0.1/mips-binutils-egcs-2.9.5-linux.tar.gz
+	wget https://github.com/decompals/mips-binutils-egcs-2.9.5/releases/download/0.4/mips-binutils-egcs-2.9.5-linux.tar.gz
 	tar xf mips-binutils-egcs-2.9.5-linux.tar.gz -C $(EGCS_DIR)
 	$(RM) mips-binutils-egcs-2.9.5-linux.tar.gz
 
 $(EGCS-1.1.2): | $(EGCS_DIR)
-	wget https://github.com/decompals/mips-gcc-egcs-2.91.66/releases/download/0.1/mips-gcc-egcs-2.91.66-linux.tar.gz
+	wget https://github.com/decompals/mips-gcc-egcs-2.91.66/releases/download/0.2/mips-gcc-egcs-2.91.66-linux.tar.gz
 	tar xf mips-gcc-egcs-2.91.66-linux.tar.gz -C $(EGCS_DIR)
 	$(RM) mips-gcc-egcs-2.91.66-linux.tar.gz
 


### PR DESCRIPTION
Re-matches any files that turned out to be non-matching due to symtab/reloc differences.