### PR TITLE
Fix two warnings

### DIFF
--- a/src/libc/xldtob.c
+++ b/src/libc/xldtob.c
@@ -160,7 +160,7 @@ void _Ldtob(_Pft* px, char code) {
 }
 
 s16 _Ldunscale(s16* pex, _Pft* px) {
-    u16* ps = px;
+    u16* ps = (u16*)px;
     s16 xchar = (ps[_D0] & _DMASK) >> _DOFF;
 
 

--- a/src/libc/xldtob.c
+++ b/src/libc/xldtob.c
@@ -116,7 +116,8 @@ void _Ldtob(_Pft* px, char code) {
                 }
 
                 for (p += 8, j = 8; lo > 0 && --j >= 0;) {
-                    ldiv_t qr = ldiv(lo, 10);
+                    ldiv_t qr;
+                    qr = ldiv(lo, 10);
                     *--p = qr.rem + '0', lo = qr.quot;
                 }
                 


### PR DESCRIPTION
I noticed the repo produces a few warnings during build.
Most of the warnings are `-mips3` related or macro asm instructions on delay slots which are sadly unfixable, so I fixed the warnings I could