### PR TITLE
Specify COMPILER_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ else
 $(error Invalid Target)
 endif
 
+SJIS_FILES := $(BUILD_DIR)/src/voice/voicecheckword.marker $(BUILD_DIR)/src/voice/voicecountsyllables.marker
+
 ifeq ($(findstring _rom,$(TARGET)),_rom)
 CPPFLAGS += -D_FINALROM
 endif
@@ -71,9 +73,10 @@ O_FILES   := $(S_O_FILES) $(C_O_FILES)
 # Because we patch the object file timestamps, we can't use them as the targets since they'll always be older than the C file
 # Therefore instead we use marker files that have actual timestamps as the dependencies for the archive
 C_MARKER_FILES := $(C_O_FILES:.o=.marker)
+C_MARKER_FILES := $(filter-out $(SJIS_FILES),$(C_MARKER_FILES))
 S_MARKER_FILES := $(S_O_FILES:.o=.marker)
 S_MARKER_FILES := $(filter-out $(MDEBUG_FILES),$(S_MARKER_FILES))
-MARKER_FILES   := $(C_MARKER_FILES) $(S_MARKER_FILES) $(MDEBUG_FILES)
+MARKER_FILES   := $(C_MARKER_FILES) $(SJIS_FILES) $(S_MARKER_FILES) $(MDEBUG_FILES)
 
 ifneq ($(COMPARE),0)
 COMPARE_OBJ = cmp $(BASE_DIR)/$(@F:.marker=.o) $(@:.marker=.o) && echo "$(@:.marker=.o): OK"
@@ -166,10 +169,28 @@ $(BUILD_DIR)/src/sp/sprite.marker: GBIDEFINE := -DF3D_GBI
 $(BUILD_DIR)/src/sp/spriteex.marker: GBIDEFINE :=
 $(BUILD_DIR)/src/sp/spriteex2.marker: GBIDEFINE :=
 $(BUILD_DIR)/src/voice/%.marker: OPTFLAGS += -DLANG_JAPANESE -I$(WORKING_DIR)/src -I$(WORKING_DIR)/src/voice
-$(BUILD_DIR)/src/voice/%.marker: CC := tools/compile_sjis.py -D__CC=$(WORKING_DIR)/$(CC) -D__BUILD_DIR=$(BUILD_DIR)
 
 $(C_MARKER_FILES): $(BUILD_DIR)/%.marker: %.c
 	cd $(<D) && $(WORKING_DIR)/$(CC) $(CFLAGS) $(MIPS_VERSION) $(CPPFLAGS) $(OPTFLAGS) $(<F) $(IINC) -o $(WORKING_DIR)/$(@:.marker=.o)
+ifneq ($(COMPARE),0)
+# check if this file is in the archive; patch corrupted bytes and change file timestamps to match original if so
+	@$(if $(findstring $(BASE_DIR)/$(@F:.marker=.o), $(BASE_OBJS)), \
+	 python3 tools/fix_objfile.py $(@:.marker=.o) $(BASE_DIR)/$(@F:.marker=.o) $(STRIP) && \
+	 $(COMPARE_OBJ) && \
+	 touch -r $(BASE_DIR)/$(@F:.marker=.o) $(@:.marker=.o), \
+	 echo "Object file $(@F:.marker=.o) is not in the current archive" \
+	)
+endif
+ifneq ($(FIXUPS),0)
+	tools/set_o32abi_bit.py $(WORKING_DIR)/$(@:.marker=.o)
+	$(CROSS)strip $(WORKING_DIR)/$(@:.marker=.o) -N asdasdasdasd
+	$(CROSS)objcopy --remove-section .mdebug $(WORKING_DIR)/$(@:.marker=.o)
+endif
+# create or update the marker file
+	@touch $@
+
+$(SJIS_FILES): $(BUILD_DIR)/%.marker: %.c
+	cd $(<D) && $(WORKING_DIR)/tools/compile_sjis.py -D__CC=$(WORKING_DIR)/$(CC) -D__BUILD_DIR=$(BUILD_DIR) $(CFLAGS) $(MIPS_VERSION) $(CPPFLAGS) $(OPTFLAGS) $(<F) $(IINC) -o $(WORKING_DIR)/$(@:.marker=.o)
 ifneq ($(COMPARE),0)
 # check if this file is in the archive; patch corrupted bytes and change file timestamps to match original if so
 	@$(if $(findstring $(BASE_DIR)/$(@F:.marker=.o), $(BASE_OBJS)), \

--- a/Makefile.gcc
+++ b/Makefile.gcc
@@ -1,11 +1,10 @@
 COMPILER := gcc
-AS := tools/gcc/as
-CC := tools/gcc/gcc
-AR_OLD := tools/gcc/ar
+COMPILER_DIR := tools/gcc/
+AS := $(COMPILER_DIR)as
+CC := $(COMPILER_DIR)gcc
+AR_OLD := $(COMPILER_DIR)ar
 PATCH_AR_FLAGS := 0 0 37777700
 STRIP =
-
-export COMPILER_PATH := $(WORKING_DIR)/tools/gcc
 
 CFLAGS := -w -nostdinc -c -G 0 -mgp32 -mfp32 -D_LANGUAGE_C
 ASFLAGS := -w -nostdinc -c -G 0 -mgp32 -mfp32 -DMIPSEB -D_LANGUAGE_ASSEMBLY -D_MIPS_SIM=1 -D_ULTRA64 -x assembler-with-cpp
@@ -46,7 +45,7 @@ endif
 export VR4300MUL := ON
 
 $(BUILD_DIR)/src/os/initialize_isv.marker: OPTFLAGS := -O2
-$(BUILD_DIR)/src/os/initialize_isv.marker: STRIP = && tools/gcc/strip-2.7 -N initialize_isv.c $(WORKING_DIR)/$(@:.marker=.o)
+$(BUILD_DIR)/src/os/initialize_isv.marker: STRIP = && $(COMPILER_DIR)strip-2.7 -N initialize_isv.c $(WORKING_DIR)/$(@:.marker=.o)
 $(BUILD_DIR)/src/os/assert.marker: OPTFLAGS := -O0
 ifeq ($(filter $(VERSION),D E F G H I),)
 $(BUILD_DIR)/src/os/seterrorhandler.marker: OPTFLAGS := -O0
@@ -63,5 +62,6 @@ $(BUILD_DIR)/src/rmon/%.marker: ASFLAGS += -P
 $(BUILD_DIR)/src/host/host_ptn64.marker: CFLAGS += -fno-builtin # Probably a better way to solve this
 
 MDEBUG_FILES := $(BUILD_DIR)/src/monutil.marker
-$(BUILD_DIR)/src/monutil.marker: CC := tools/ido/cc
-$(BUILD_DIR)/src/monutil.marker: ASFLAGS := -non_shared -mips2 -fullwarn -verbose -Xcpluscomm -G 0 -woff 516,649,838,712 -Wab,-r4300_mul -nostdinc -o32 -c
+MDEBUG_COMPILER_DIR := tools/ido/
+$(MDEBUG_FILES): CC := $(MDEBUG_COMPILER_DIR)cc
+$(MDEBUG_FILES): ASFLAGS := -non_shared -mips2 -fullwarn -verbose -Xcpluscomm -G 0 -woff 516,649,838,712 -Wab,-r4300_mul -nostdinc -o32 -c

--- a/Makefile.ido
+++ b/Makefile.ido
@@ -1,11 +1,10 @@
 COMPILER := ido
-AS := tools/ido/cc
-CC := tools/ido/cc
+COMPILER_DIR := tools/ido/
+AS := $(COMPILER_DIR)cc
+CC := $(COMPILER_DIR)cc
 AR_OLD := tools/ar.py
 PATCH_AR_FLAGS := 40001 110 100644
 STRIP =
-
-export COMPILER_PATH := $(WORKING_DIR)/tools/ido
 
 CFLAGS := -c -Wab,-r4300_mul -G 0 -nostdinc -Xcpluscomm -fullwarn -woff 516,649,838,712
 ASFLAGS := -c -Wab,-r4300_mul -G 0 -nostdinc -woff 516,649,838,712


### PR DESCRIPTION
Since sjis files currently overwrite `CC` in the makefile, if you overwrite `CC` when calling make sjis files won't compile properly. So for example if you have the compiler already downloaded in a project, you would still need to have ultralib download a copy as well (`make setup`). This PR separates SJIS files into their own makefile recipe so it can just call `compile_sjis.py` without needing to overwrite `CC`.