### PR TITLE
"Fix" assembly func definitions when building with `COMPARE=0` or modern gcc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ build/
 expected/
 notes/
 tools/gcc
+tools/egcs
+tools/egcs_original
 tools/ido
 *.elf
 *.o
@@ -25,5 +27,6 @@ tools/ido
 
 # Tool artifacts
 ctx.c
+ctx.c.m2c
 
 libultra_collection/

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ CPPFLAGS += -D_FINALROM
 endif
 
 ifneq ($(COMPILER),ido)
-	ifneq ($(COMPARE),0)
+	ifeq ($(COMPARE),0)
 	CPPFLAGS += -D ASM_FIXUPS=1
 	endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,12 @@ ifeq ($(findstring _rom,$(TARGET)),_rom)
 CPPFLAGS += -D_FINALROM
 endif
 
+ifeq ($(COMPARE),0)
+CPPFLAGS += -D COMPARE=0
+else
+CPPFLAGS += -D COMPARE=1
+endif
+
 SRC_DIRS := $(shell find src -type d)
 C_FILES  := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c))
 S_FILES  := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.s))

--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,10 @@ ifeq ($(findstring _rom,$(TARGET)),_rom)
 CPPFLAGS += -D_FINALROM
 endif
 
-ifeq ($(COMPARE),0)
-CPPFLAGS += -D COMPARE=0
-else
-CPPFLAGS += -D COMPARE=1
+ifneq ($(COMPILER),ido)
+	ifneq ($(COMPARE),0)
+	CPPFLAGS += -D ASM_FIXUPS=1
+	endif
 endif
 
 SRC_DIRS := $(shell find src -type d)

--- a/include/sys/asm.h
+++ b/include/sys/asm.h
@@ -67,6 +67,18 @@ extern "C" {
     .end    proc
 #endif
 
+/* Some specific asm functions (guMtxCatF, _bcmp, _bcopy, _bzero) do not use a .size directive
+   in any known libultra version, so this macro is used to allow using said directive on those
+   functions without breaking matching the archives. */
+#if defined(MODERN_CC) || (defined(ASM_FIXUPS) && !defined(__sgi))
+#define END2(proc)           \
+    .end    proc           ;\
+    .size   proc, . - proc
+#else
+#define END2(proc)   \
+    .end    proc
+#endif
+
 #define ABS(x, y)   \
     .globl  x      ;\
     x   =   y

--- a/include/sys/asm.h
+++ b/include/sys/asm.h
@@ -34,7 +34,7 @@ extern "C" {
 
 
 /* libgultra doesn't match with the .type directive but iQue sdk asm.h uses it */
-#if defined(BBPLAYER) || defined(MODERN_CC) || (defined(ASM_FIXUPS) && !defined(__sgi))
+#if defined(BBPLAYER) || (defined(ASM_FIXUPS) && !defined(__sgi))
 #define ASM_TYPE_FUNC(x)    .type   x, @function
 #else
 #define ASM_TYPE_FUNC(x)
@@ -48,7 +48,7 @@ extern "C" {
     x:                     ;\
     .frame  sp,0,ra
 
-#if defined(BBPLAYER) || defined(__sgi) || defined(MODERN_CC) || defined(ASM_FIXUPS)
+#if defined(BBPLAYER) || defined(__sgi) || defined(ASM_FIXUPS)
 #define XLEAF(x)    \
     .globl  x      ;\
     .aent   x,0    ;\
@@ -58,7 +58,7 @@ extern "C" {
     .globl  x
 #endif
 
-#if defined(BBPLAYER) || defined(MODERN_CC) || (defined(ASM_FIXUPS) && !defined(__sgi))
+#if defined(BBPLAYER) || (defined(ASM_FIXUPS) && !defined(__sgi))
 #define END(proc)           \
     .end    proc           ;\
     .size   proc, . - proc
@@ -70,7 +70,7 @@ extern "C" {
 /* Some specific asm functions (guMtxCatF, _bcmp, _bcopy, _bzero) do not use a .size directive
    in any known libultra version, so this macro is used to allow using said directive on those
    functions without breaking matching the archives. */
-#if defined(MODERN_CC) || (defined(ASM_FIXUPS) && !defined(__sgi))
+#if (defined(ASM_FIXUPS) && !defined(__sgi))
 #define END2(proc)           \
     .end    proc           ;\
     .size   proc, . - proc
@@ -87,7 +87,7 @@ extern "C" {
     .globl  x      ;\
     x:
 
-#if defined(BBPLAYER) || defined(__sgi) || defined(MODERN_CC) || defined(ASM_FIXUPS)
+#if defined(BBPLAYER) || defined(__sgi) || defined(ASM_FIXUPS)
 #define WEAK(x, y)      \
     .weakext    x,  y
 #else

--- a/include/sys/asm.h
+++ b/include/sys/asm.h
@@ -34,7 +34,7 @@ extern "C" {
 
 
 /* libgultra doesn't match with the .type directive but iQue sdk asm.h uses it */
-#if defined(BBPLAYER) || defined(MODERN_CC) || (COMPARE == 0)
+#if defined(BBPLAYER) || defined(MODERN_CC) || (defined(ASM_FIXUPS) && !defined(__sgi))
 #define ASM_TYPE_FUNC(x)    .type   x, @function
 #else
 #define ASM_TYPE_FUNC(x)
@@ -48,7 +48,7 @@ extern "C" {
     x:                     ;\
     .frame  sp,0,ra
 
-#if defined(BBPLAYER) || defined(__sgi) || defined(MODERN_CC) || (COMPARE == 0)
+#if defined(BBPLAYER) || defined(__sgi) || defined(MODERN_CC) || defined(ASM_FIXUPS)
 #define XLEAF(x)    \
     .globl  x      ;\
     .aent   x,0    ;\
@@ -58,7 +58,7 @@ extern "C" {
     .globl  x
 #endif
 
-#if defined(BBPLAYER) || defined(MODERN_CC) || (COMPARE == 0)
+#if defined(BBPLAYER) || defined(MODERN_CC) || (defined(ASM_FIXUPS) && !defined(__sgi))
 #define END(proc)           \
     .end    proc           ;\
     .size   proc, . - proc
@@ -75,7 +75,7 @@ extern "C" {
     .globl  x      ;\
     x:
 
-#if defined(BBPLAYER) || defined(__sgi) || defined(MODERN_CC) || (COMPARE == 0)
+#if defined(BBPLAYER) || defined(__sgi) || defined(MODERN_CC) || defined(ASM_FIXUPS)
 #define WEAK(x, y)      \
     .weakext    x,  y
 #else

--- a/include/sys/asm.h
+++ b/include/sys/asm.h
@@ -34,7 +34,7 @@ extern "C" {
 
 
 /* libgultra doesn't match with the .type directive but iQue sdk asm.h uses it */
-#ifdef BBPLAYER
+#if defined(BBPLAYER) || defined(MODERN_CC) || (COMPARE == 0)
 #define ASM_TYPE_FUNC(x)    .type   x, @function
 #else
 #define ASM_TYPE_FUNC(x)
@@ -48,7 +48,7 @@ extern "C" {
     x:                     ;\
     .frame  sp,0,ra
 
-#if defined(BBPLAYER) || defined(__sgi)
+#if defined(BBPLAYER) || defined(__sgi) || defined(MODERN_CC) || (COMPARE == 0)
 #define XLEAF(x)    \
     .globl  x      ;\
     .aent   x,0    ;\
@@ -58,7 +58,7 @@ extern "C" {
     .globl  x
 #endif
 
-#ifdef BBPLAYER
+#if defined(BBPLAYER) || defined(MODERN_CC) || (COMPARE == 0)
 #define END(proc)           \
     .end    proc           ;\
     .size   proc, . - proc
@@ -75,7 +75,7 @@ extern "C" {
     .globl  x      ;\
     x:
 
-#if defined(BBPLAYER) || defined(__sgi)
+#if defined(BBPLAYER) || defined(__sgi) || defined(MODERN_CC) || (COMPARE == 0)
 #define WEAK(x, y)      \
     .weakext    x,  y
 #else

--- a/makefiles/modern_gcc.mk
+++ b/makefiles/modern_gcc.mk
@@ -9,7 +9,7 @@ WARNINGS += -Wno-int-conversion -Wno-incompatible-pointer-types -Wno-implicit-fu
 CFLAGS := -G 0 -c -nostdinc -march=vr4300 -mfix4300 -mabi=32 -mno-abicalls -mdivide-breaks -fno-PIC -fno-common -ffreestanding -fbuiltin -fno-builtin-sinf -fno-builtin-cosf -funsigned-char $(WARNINGS)
 CFLAGS += -fno-strict-aliasing # TODO: Try adjusting code to remove this
 ASFLAGS := -w -nostdinc -c -G 0 -march=vr4300 -mgp32 -mfp32 -DMIPSEB -D_LANGUAGE_ASSEMBLY -D_MIPS_SIM=1 -D_ULTRA64
-CPPFLAGS = -DMODERN_CC -D_MIPS_SZLONG=32 -D__USE_ISOC99 $(GBIDEFINE) $(VERSION_DEFINE) $(DEBUGFLAG)
+CPPFLAGS = -DMODERN_CC -D ASM_FIXUPS=1 -D_MIPS_SZLONG=32 -D__USE_ISOC99 $(GBIDEFINE) $(VERSION_DEFINE) $(DEBUGFLAG)
 IINC = -I . -I $(WORKING_DIR)/include -I $(WORKING_DIR)/include/compiler/modern_gcc -I $(WORKING_DIR)/include/PR
 MIPS_VERSION := -mips3
 ASOPTFLAGS :=

--- a/src/libc/bcmp.s
+++ b/src/libc/bcmp.s
@@ -93,4 +93,4 @@ cmpne:
     li      v0, 1
     jr      ra
 
-END(_bcmp)
+END2(_bcmp)

--- a/src/libc/bcmp.s
+++ b/src/libc/bcmp.s
@@ -93,4 +93,4 @@ cmpne:
     li      v0, 1
     jr      ra
 
-.end _bcmp
+END(_bcmp)

--- a/src/libc/bcopy.s
+++ b/src/libc/bcopy.s
@@ -217,4 +217,4 @@ backwards_4:
     addiu   a2, a2, -4
     b       backwards_4
 
-.end _bcopy
+END(_bcopy)

--- a/src/libc/bcopy.s
+++ b/src/libc/bcopy.s
@@ -217,4 +217,4 @@ backwards_4:
     addiu   a2, a2, -4
     b       backwards_4
 
-END(_bcopy)
+END2(_bcopy)

--- a/src/libc/bzero.s
+++ b/src/libc/bzero.s
@@ -69,4 +69,4 @@ bytezero:
 zerodone:
     jr      ra
 
-END(_bzero)
+END2(_bzero)

--- a/src/libc/bzero.s
+++ b/src/libc/bzero.s
@@ -69,4 +69,4 @@ bytezero:
 zerodone:
     jr      ra
 
-.end _bzero
+END(_bzero)

--- a/src/mgu/asm.h
+++ b/src/mgu/asm.h
@@ -32,7 +32,7 @@ extern "C" {
 		/* NABI32 is 64bit calling convention but 32bit type sizes) */
 #define _MIPS_SIM_ABI64		3	/* MIPS 64 calling convention */
 
-#if defined(MODERN_CC) || (defined(ASM_FIXUPS) && !defined(__sgi))
+#if (defined(ASM_FIXUPS) && !defined(__sgi))
 #define ASM_TYPE_FUNC(x)    .type   x, @function
 #else
 #define ASM_TYPE_FUNC(x)
@@ -45,7 +45,7 @@ extern "C" {
 x:;							\
 	.frame	sp,0,ra
 
-#if defined(MODERN_CC) || (defined(ASM_FIXUPS) && !defined(__sgi))
+#if (defined(ASM_FIXUPS) && !defined(__sgi))
 #define END(proc)           \
     .end    proc           ;\
     .size   proc, . - proc

--- a/src/mgu/asm.h
+++ b/src/mgu/asm.h
@@ -32,14 +32,27 @@ extern "C" {
 		/* NABI32 is 64bit calling convention but 32bit type sizes) */
 #define _MIPS_SIM_ABI64		3	/* MIPS 64 calling convention */
 
+#if defined(MODERN_CC) || (defined(ASM_FIXUPS) && !defined(__sgi))
+#define ASM_TYPE_FUNC(x)    .type   x, @function
+#else
+#define ASM_TYPE_FUNC(x)
+#endif
+
 #define	LEAF(x)						\
 	.globl	x;					\
+    ASM_TYPE_FUNC(x)       ;\
 	.ent	x,0;					\
 x:;							\
 	.frame	sp,0,ra
 
+#if defined(MODERN_CC) || (defined(ASM_FIXUPS) && !defined(__sgi))
+#define END(proc)           \
+    .end    proc           ;\
+    .size   proc, . - proc
+#else
 #define	END(proc)					\
 	.end	proc
+#endif
 
 
 #ifdef __cplusplus

--- a/src/mgu/mtxcatf.s
+++ b/src/mgu/mtxcatf.s
@@ -98,6 +98,6 @@ label_loop_j:
 	addu	sp , FRAME_SIZE
 	j	ra
 
-	.end	guMtxCatF
+	END(guMtxCatF)
 
 /* end of file */

--- a/src/mgu/mtxcatf.s
+++ b/src/mgu/mtxcatf.s
@@ -98,6 +98,6 @@ label_loop_j:
 	addu	sp , FRAME_SIZE
 	j	ra
 
-	END2(guMtxCatF)
+	END(guMtxCatF)
 
 /* end of file */

--- a/src/mgu/mtxcatf.s
+++ b/src/mgu/mtxcatf.s
@@ -98,6 +98,6 @@ label_loop_j:
 	addu	sp , FRAME_SIZE
 	j	ra
 
-	END(guMtxCatF)
+	END2(guMtxCatF)
 
 /* end of file */


### PR DESCRIPTION
Changes the behavior of the assembly macros when building with `COMPARE=0` or when using modern gcc instead of the original compilers.
This produces "better quality" object elf files, which can matter on some niche scenarios.
