### PR TITLE
Add wget as requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ The build process requires the following packages:
 - build-essential
 - python3
 - binutils-mips-linux-gnu (libultra* only)
+- wget
 
-Under Debian / Ubunutu you can install them with the following commands:
+Under Debian / Ubuntu you can install them with the following commands:
 
 ```bash
 sudo apt update
-sudo apt install build-essential python3
+sudo apt install build-essential python3 wget
 ```
 
 If building any libultra you can install binutils-mips-linux-gnu with:
@@ -49,7 +50,7 @@ sudo apt install binutils-mips-linux-gnu
 ## Building
 
 Run make setup with the proper flags set followed by make with optional jobs.
-For example, if building the 2.0L PC archive you'd do the following: 
+For example, if building the 2.0L PC archive you'd do the following:
 
 - `make VERSION=L TARGET=libgultra_rom setup`
 - `make VERSION=L TARGET=libgultra_rom`


### PR DESCRIPTION
This is a low quality PR I know, but I tried to build ultralib in a clean Ubuntu 24.04 install and I needed `wget` for the `make setup` step, so adding it to the readme for completeness.