### PR TITLE
Update download links in Makefile to latest releases

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,4 +1,3 @@
-
 .PHONY: all clean distclean
 
 # GCC
@@ -14,17 +13,17 @@ IDO-5.3   := $(IDO_DIR)/cc
 all: $(AR) $(GCC-2.7.2) $(STRIP-2.7) $(IDO-5.3)
 
 $(AR): | $(GCC_DIR)
-	wget https://github.com/decompals/mips-binutils-2.6/releases/download/main/binutils-2.6-linux.tar.gz
+	wget https://github.com/decompals/mips-binutils-2.6/releases/latest/download/binutils-2.6-linux.tar.gz
 	tar xf binutils-2.6-linux.tar.gz -C $(GCC_DIR)
 	$(RM) binutils-2.6-linux.tar.gz
 
 $(GCC-2.7.2): | $(GCC_DIR)
-	wget https://github.com/decompals/mips-gcc-2.7.2/releases/download/main/gcc-2.7.2-linux.tar.gz
+	wget https://github.com/decompals/mips-gcc-2.7.2/releases/latest/download/gcc-2.7.2-linux.tar.gz
 	tar xf gcc-2.7.2-linux.tar.gz -C $(GCC_DIR)
 	$(RM) gcc-2.7.2-linux.tar.gz
 
 $(STRIP-2.7): | $(GCC_DIR)
-	wget https://github.com/decompals/mips-binutils-2.7/releases/download/release/binutils-2.7.tar.gz
+	wget https://github.com/decompals/mips-binutils-2.7/releases/latest/download/binutils-2.7.tar.gz
 	tar xf binutils-2.7.tar.gz -C $(GCC_DIR)
 	$(RM) binutils-2.7.tar.gz
 


### PR DESCRIPTION
The branch for these utils has changed from main to main-old, breaking all the download links.