### PR TITLE
Remove usage of `pull_request_target` and GHA secrets from CI

### DIFF
--- a/.github/workflows/ci_egcs.txt
+++ b/.github/workflows/ci_egcs.txt
@@ -4,10 +4,15 @@
 name: Build EGCS libultra
 
 # Build on every branch push, tag push, and pull request change:
-on: [push, pull_request_target]
+on:
+  push:
+  pull_request:
 
 jobs:
   build_repo:
+    # This is a *private* build container.
+    container: ghcr.io/decompals/ultralib-build:main
+
     name: Build repo
     runs-on: ubuntu-latest
 
@@ -18,25 +23,17 @@ jobs:
         suffix: [_rom] # [~, _d, _rom]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-    - name: Install package requirements
-      run: sudo apt-get install -y build-essential python3
+      - name: Install package requirements
+        run: sudo apt-get install -y build-essential python3
 
-    - name: Get extra dependencies
-      uses: actions/checkout@v3
-      with:
-        repository: ${{ secrets.SECRETREPO }}
-        token: ${{ secrets.SECRETTOKEN }}
-        path: deps_repo
-    - name: Get the dependency
-      run: cp deps_repo/libultra/${{ matrix.version }}/* .
+      - name: Get the dependency
+        run: cp /orig/${{ matrix.version }}/* base/${{ matrix.version }}
 
-    - name: Setup
-      run: make setup -j $(nproc) TARGET=libultra${{ matrix.suffix }} VERSION=${{ matrix.version }}
+      - name: Setup
+        run: make setup -j $(nproc) TARGET=libultra${{ matrix.suffix }} VERSION=${{ matrix.version }}
 
-    - name: Build libultra${{ matrix.suffix }} ${{ matrix.version }}
-      run: make -j $(nproc) TARGET=libultra${{ matrix.suffix }} VERSION=${{ matrix.version }}
+      - name: Build libultra${{ matrix.suffix }} ${{ matrix.version }}
+        run: make -j $(nproc) TARGET=libultra${{ matrix.suffix }} VERSION=${{ matrix.version }}

--- a/.github/workflows/ci_egcs.txt
+++ b/.github/workflows/ci_egcs.txt
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install package requirements
-        run: sudo apt-get install -y build-essential python3
+        run: apt-get install -y build-essential python3
 
       - name: Get the dependency
         run: cp /orig/${{ matrix.version }}/* base/${{ matrix.version }}

--- a/.github/workflows/ci_gcc.yml
+++ b/.github/workflows/ci_gcc.yml
@@ -3,10 +3,15 @@
 name: Build GCC libgultra
 
 # Build on every branch push, tag push, and pull request change:
-on: [push, pull_request_target]
+on:
+  push:
+  pull_request:
 
 jobs:
   build_repo:
+    # This is a *private* build container.
+    container: ghcr.io/decompals/ultralib-build:main
+
     name: Build repo
     runs-on: ubuntu-latest
 
@@ -17,25 +22,17 @@ jobs:
         suffix: [~, _d, _rom]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-    - name: Install package requirements
-      run: sudo apt-get install -y binutils-mips-linux-gnu build-essential python3
+      - name: Install package requirements
+        run: sudo apt-get install -y binutils-mips-linux-gnu build-essential python3
 
-    - name: Get extra dependencies
-      uses: actions/checkout@v3
-      with:
-        repository: ${{ secrets.SECRETREPO }}
-        token: ${{ secrets.SECRETTOKEN }}
-        path: deps_repo
-    - name: Get the dependency
-      run: cp deps_repo/libultra/${{ matrix.version }}/* base/${{ matrix.version }}
+      - name: Get the dependency
+        run: cp /orig/${{ matrix.version }}/* base/${{ matrix.version }}
 
-    - name: Setup
-      run: make setup -j $(nproc) TARGET=libgultra${{ matrix.suffix }} VERSION=${{ matrix.version }}
+      - name: Setup
+        run: make setup -j $(nproc) TARGET=libgultra${{ matrix.suffix }} VERSION=${{ matrix.version }}
 
-    - name: Build libgultra${{ matrix.suffix }} ${{ matrix.version }}
-      run: make -j $(nproc) TARGET=libgultra${{ matrix.suffix }} VERSION=${{ matrix.version }}
+      - name: Build libgultra${{ matrix.suffix }} ${{ matrix.version }}
+        run: make -j $(nproc) TARGET=libgultra${{ matrix.suffix }} VERSION=${{ matrix.version }}

--- a/.github/workflows/ci_gcc.yml
+++ b/.github/workflows/ci_gcc.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install package requirements
-        run: sudo apt-get install -y binutils-mips-linux-gnu build-essential python3
+        run: apt-get install -y binutils-mips-linux-gnu build-essential python3
 
       - name: Get the dependency
         run: cp /orig/${{ matrix.version }}/* base/${{ matrix.version }}

--- a/.github/workflows/ci_ido.yml
+++ b/.github/workflows/ci_ido.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install package requirements
-        run: sudo apt-get install -y build-essential python3 binutils-mips-linux-gnu
+        run: apt-get install -y build-essential python3 binutils-mips-linux-gnu
 
       - name: Get the dependency
         run: cp /orig/${{ matrix.version }}/* base/${{ matrix.version }}

--- a/.github/workflows/ci_ido.yml
+++ b/.github/workflows/ci_ido.yml
@@ -3,10 +3,15 @@
 name: Build IDO libultra
 
 # Build on every branch push, tag push, and pull request change:
-on: [push, pull_request_target]
+on:
+  push:
+  pull_request:
 
 jobs:
   build_repo:
+    # This is a *private* build container.
+    container: ghcr.io/decompals/ultralib-build:main
+
     name: Build repo
     runs-on: ubuntu-latest
 
@@ -17,25 +22,17 @@ jobs:
         suffix: [~, _rom] # [~, _d, _rom]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-    - name: Install package requirements
-      run: sudo apt-get install -y build-essential python3 binutils-mips-linux-gnu
+      - name: Install package requirements
+        run: sudo apt-get install -y build-essential python3 binutils-mips-linux-gnu
 
-    - name: Get extra dependencies
-      uses: actions/checkout@v3
-      with:
-        repository: ${{ secrets.SECRETREPO }}
-        token: ${{ secrets.SECRETTOKEN }}
-        path: deps_repo
-    - name: Get the dependency
-      run: cp deps_repo/libultra/${{ matrix.version }}/* base/${{ matrix.version }}
+      - name: Get the dependency
+        run: cp /orig/${{ matrix.version }}/* base/${{ matrix.version }}
 
-    - name: Setup
-      run: make setup -j $(nproc) TARGET=libultra${{ matrix.suffix }} VERSION=${{ matrix.version }}
+      - name: Setup
+        run: make setup -j $(nproc) TARGET=libultra${{ matrix.suffix }} VERSION=${{ matrix.version }}
 
-    - name: Build libultra${{ matrix.suffix }} ${{ matrix.version }}
-      run: make -j $(nproc) TARGET=libultra${{ matrix.suffix }} VERSION=${{ matrix.version }}
+      - name: Build libultra${{ matrix.suffix }} ${{ matrix.version }}
+        run: make -j $(nproc) TARGET=libultra${{ matrix.suffix }} VERSION=${{ matrix.version }}


### PR DESCRIPTION
Uses the same docker approach from the GC/Wii community.

There's a write up about this approach here: https://github.com/AngheloAlf/drmario64/pull/19

The main motivation for getting rid of `pull_request_target` is that it was making this repo a target for bad actors trying to steal repository secrets.

`pull_request_target` bypasses the require approval before running CI on a PR check, making it an easy target for bad people.

This approach uses a docker image that contains the important and unique dependencies needed to build the repo